### PR TITLE
Fix wrong section names in systemd config files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,6 @@
 #     value: info
 
 # Set options in user.conf. For example:
-# systemd_logind:
+# systemd_user:
 #   - option: DefaultStartLimitBurst
 #     value: 5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: configure coredump.conf
   community.general.ini_file:
     path: /etc/systemd/coredump.conf
-    section: Login
+    section: Coredump
     option: "{{ item.option }}"
     value: "{{ item.value }}"
     mode: "0644"
@@ -36,7 +36,7 @@
 - name: configure journald.conf
   community.general.ini_file:
     path: /etc/systemd/journald.conf
-    section: Login
+    section: Journal
     option: "{{ item.option }}"
     value: "{{ item.value }}"
     mode: "0644"
@@ -66,7 +66,7 @@
 - name: configure resolved.conf
   community.general.ini_file:
     path: /etc/systemd/resolved.conf
-    section: Login
+    section: Resolve
     option: "{{ item.option }}"
     value: "{{ item.value }}"
     mode: "0644"
@@ -79,7 +79,7 @@
 - name: configure system.conf
   community.general.ini_file:
     path: /etc/systemd/system.conf
-    section: Login
+    section: Manager
     option: "{{ item.option }}"
     value: "{{ item.value }}"
     mode: "0644"
@@ -92,7 +92,7 @@
 - name: configure user.conf
   community.general.ini_file:
     path: /etc/systemd/user.conf
-    section: Login
+    section: Manager
     option: "{{ item.option }}"
     value: "{{ item.value }}"
     mode: "0644"


### PR DESCRIPTION
I've stumbled across this while trying to configure `resolved` but all additional configuration files are affected.